### PR TITLE
Remove float32 mention and add regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ pip install -U toploc
 ## Usage
 
 ### Build proofs from activations:
+Supported activation dtypes are `bfloat16`, `float16`, or integer tensors. `float32` is not currently supported.
 As bytes (more compact when stored in binary formats):
 ```python
 import torch

--- a/tests/test_poly.py
+++ b/tests/test_poly.py
@@ -85,6 +85,14 @@ def test_proof_poly_from_points_bfloat16():
     assert len(poly.coeffs) == 3
 
 
+def test_proof_poly_from_points_float32_error():
+    """float32 inputs should raise ValueError"""
+    x = torch.tensor([1, 2, 3])
+    y = torch.tensor([4, 5, 6], dtype=torch.float32)
+    with pytest.raises(ValueError):
+        ProofPoly.from_points_tensor(x, y)
+
+
 def test_proof_poly_to_base64(sample_poly):
     """Test base64 encoding"""
     encoded = sample_poly.to_base64()

--- a/toploc/C/csrc/poly.pyi
+++ b/toploc/C/csrc/poly.pyi
@@ -21,7 +21,7 @@ class ProofPoly:
         Create a polynomial from a tensor of x and y values.
         x and y must be 1D tensors of the same length.
         x must be of dtype [int32, uint32, long]
-        y must be of dtype [float16, bfloat16, float32]
+        y must be of dtype [float16, bfloat16, int32, uint32, long]
         """
         ...
 


### PR DESCRIPTION
## Summary
- update proof docstring for supported dtypes
- document supported dtypes in README
- test that float32 tensors raise `ValueError`

## Testing
- `ruff check toploc/C/csrc/poly.pyi tests/test_poly.py`